### PR TITLE
[Fix] DiaryStatus, MoodBuddyStatus를 고려하지 못 한 에러를 해결

### DIFF
--- a/src/main/java/moodbuddy/moodbuddy/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/moodbuddy/moodbuddy/domain/diary/repository/DiaryRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryRepositoryCustom {
     Optional<Diary> findByDiaryDateAndUserIdAndDiaryStatus(LocalDate diaryDate, Long userId, DiaryStatus diaryStatus);
     List<Diary> findAllByDiaryDateAndUserIdAndDiaryStatus(LocalDate diaryDate, Long userId, DiaryStatus diaryStatus);
-    Optional<Diary> findByDiaryIdAndMoodBuddyStatus(Long diaryId, MoodBuddyStatus moodBuddyStatus);
+    Optional<Diary> findByDiaryIdAndDiaryStatusAndMoodBuddyStatus(Long diaryId, DiaryStatus diaryStatus, MoodBuddyStatus moodBuddyStatus);
 
 
     @Query(value = "SELECT * FROM diary WHERE user_id = :userId AND DATE_FORMAT(diary_date, '%Y-%m') = :month AND diary_status = :status", nativeQuery = true)

--- a/src/main/java/moodbuddy/moodbuddy/domain/diary/repository/draft/DraftDiaryRepository.java
+++ b/src/main/java/moodbuddy/moodbuddy/domain/diary/repository/draft/DraftDiaryRepository.java
@@ -1,11 +1,12 @@
 package moodbuddy.moodbuddy.domain.diary.repository.draft;
 
 import moodbuddy.moodbuddy.domain.diary.domain.Diary;
+import moodbuddy.moodbuddy.domain.diary.domain.type.DiaryStatus;
 import moodbuddy.moodbuddy.global.common.base.MoodBuddyStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface DraftDiaryRepository extends JpaRepository<Diary, Long>, DraftDiaryRepositoryCustom {
-    Optional<Diary> findByDiaryIdAndMoodBuddyStatus(Long diaryId, MoodBuddyStatus moodBuddyStatus);
+    Optional<Diary> findByDiaryIdAndDiaryStatusAndMoodBuddyStatus(Long diaryId, DiaryStatus diaryStatus, MoodBuddyStatus moodBuddyStatus);
 }

--- a/src/main/java/moodbuddy/moodbuddy/domain/diary/repository/find/DiaryFindRepositoryImpl.java
+++ b/src/main/java/moodbuddy/moodbuddy/domain/diary/repository/find/DiaryFindRepositoryImpl.java
@@ -84,7 +84,10 @@ public class DiaryFindRepositoryImpl implements DiaryFindRepositoryCustom {
     @Override
     public Page<DiaryResDetailDTO> findAllByEmotionWithPageable(DiaryEmotion emotion, Long userId, Pageable pageable) {
         List<Diary> diaries = queryFactory.selectFrom(diary)
-                .where(diaryEmotionEq(emotion).and(diary.userId.eq(userId).and(diary.moodBuddyStatus.eq(MoodBuddyStatus.ACTIVE))))
+                .where(diaryEmotionEq(emotion).and(diary.userId.eq(userId)
+                        .and(diary.moodBuddyStatus.eq(MoodBuddyStatus.ACTIVE)
+                        .and(diary.diaryStatus.eq(DiaryStatus.PUBLISHED))
+                        )))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -156,7 +159,9 @@ public class DiaryFindRepositoryImpl implements DiaryFindRepositoryCustom {
         }
 
         List<Diary> results = queryFactory.selectFrom(diary)
-                .where(builder)
+                .where(builder
+                        .and(diary.diaryStatus.eq(DiaryStatus.PUBLISHED)
+                        .and(diary.moodBuddyStatus.eq(MoodBuddyStatus.ACTIVE))))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/moodbuddy/moodbuddy/domain/diary/service/DiaryServiceImpl.java
+++ b/src/main/java/moodbuddy/moodbuddy/domain/diary/service/DiaryServiceImpl.java
@@ -86,7 +86,7 @@ public class DiaryServiceImpl implements DiaryService {
 
     @Override
     public Diary getDiaryById(Long diaryId) {
-        return diaryRepository.findByDiaryIdAndMoodBuddyStatus(diaryId, MoodBuddyStatus.ACTIVE)
+        return diaryRepository.findByDiaryIdAndDiaryStatusAndMoodBuddyStatus(diaryId, DiaryStatus.PUBLISHED, MoodBuddyStatus.ACTIVE)
                 .orElseThrow(() -> new DiaryNotFoundException(NOT_FOUND_DIARY));
     }
 }

--- a/src/main/java/moodbuddy/moodbuddy/domain/diary/service/draft/DraftDiaryServiceImpl.java
+++ b/src/main/java/moodbuddy/moodbuddy/domain/diary/service/draft/DraftDiaryServiceImpl.java
@@ -2,6 +2,7 @@ package moodbuddy.moodbuddy.domain.diary.service.draft;
 
 import lombok.RequiredArgsConstructor;
 import moodbuddy.moodbuddy.domain.diary.domain.Diary;
+import moodbuddy.moodbuddy.domain.diary.domain.type.DiaryStatus;
 import moodbuddy.moodbuddy.domain.diary.dto.request.draft.DiaryReqDraftSelectDeleteDTO;
 import moodbuddy.moodbuddy.domain.diary.dto.request.DiaryReqSaveDTO;
 import moodbuddy.moodbuddy.domain.diary.dto.response.draft.DiaryResDraftFindAllDTO;
@@ -41,7 +42,7 @@ public class DraftDiaryServiceImpl implements DraftDiaryService {
     }
 
     private Diary getDraftDiaryById(Long diaryId) {
-        return draftDiaryRepository.findByDiaryIdAndMoodBuddyStatus(diaryId, MoodBuddyStatus.ACTIVE)
+        return draftDiaryRepository.findByDiaryIdAndDiaryStatusAndMoodBuddyStatus(diaryId, DiaryStatus.DRAFT, MoodBuddyStatus.ACTIVE)
                 .orElseThrow(() -> new DiaryNotFoundException(NOT_FOUND_DRAFT_DIARY));
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- fix/#25

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 일기 조회 할 때 ACTIVE만 조회되게 구현
- 임시 저장 삭제 할 때 PUBLISHED도 삭제되는 에러 해결
- 일기 조회 로직에서 PUBLISHED, ACTIVE만 조회되게 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #25