### PR TITLE
[Fix] DiaryStatus, MoodBuddyStatus를 고려하지 못 한 에러를 해결

### DIFF
--- a/src/main/java/moodbuddy/moodbuddy/domain/diary/repository/find/DiaryFindRepositoryImpl.java
+++ b/src/main/java/moodbuddy/moodbuddy/domain/diary/repository/find/DiaryFindRepositoryImpl.java
@@ -52,7 +52,7 @@ public class DiaryFindRepositoryImpl implements DiaryFindRepositoryCustom {
         List<DiaryResDetailDTO> diaryList = diaries.stream().map(d -> {
             List<String> diaryImgList = queryFactory.select(diaryImage.diaryImgURL)
                     .from(diaryImage)
-                    .where(diaryImage.diaryId.eq(d.getDiaryId()))
+                    .where(diaryImage.diaryId.eq(d.getDiaryId()).and(diaryImage.moodBuddyStatus.eq(MoodBuddyStatus.ACTIVE)))
                     .fetch();
 
             return DiaryResDetailDTO.builder()
@@ -93,7 +93,8 @@ public class DiaryFindRepositoryImpl implements DiaryFindRepositoryCustom {
                 .fetch();
 
         Map<Long, List<String>> diaryImages = queryFactory.selectFrom(diaryImage)
-                .where(diaryImage.diaryId.in(diaries.stream().map(Diary::getDiaryId).collect(Collectors.toList())))
+                .where(diaryImage.diaryId.in(diaries.stream().map(Diary::getDiaryId).collect(Collectors.toList()))
+                        .and(diaryImage.moodBuddyStatus.eq(MoodBuddyStatus.ACTIVE)))
                 .fetch()
                 .stream()
                 .collect(Collectors.groupingBy(


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- fix/#25

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 일기 조회 할 때 ACTIVE만 조회되게 구현
- 임시 저장 삭제 할 때 PUBLISHED도 삭제되는 에러 해결
- 일기 조회 로직에서 PUBLISHED, ACTIVE만 조회되게 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #25 